### PR TITLE
Import (chicken condition) under CHICKEN 5.

### DIFF
--- a/srfi-64.scm
+++ b/srfi-64.scm
@@ -5,5 +5,6 @@
      (import chicken)
      (use numbers))
     (chicken-5
-     (import (chicken base) (chicken module))))
+     (import (chicken base) (chicken module)
+             (chicken condition))))
   (include "srfi-64/srfi-64-port.scm"))


### PR DESCRIPTION
I encountered syntax errors related to `condition-case` while running SRFI 64 test suites under CHICKEN 5. This commit fixes the issue by importing the relevant library.